### PR TITLE
TS-1278 Update to dotnet 6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ executors:
       - image: "hashicorp/terraform:light"
   docker-dotnet:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:6.0
+      - image: mcr.microsoft.com/dotnet/sdk:6.0
 
 references:
   workspace_root: &workspace_root "~"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ executors:
       - image: "hashicorp/terraform:light"
   docker-dotnet:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:3.1
+      - image: mcr.microsoft.com/dotnet/core/sdk:6.0
 
 references:
   workspace_root: &workspace_root "~"
@@ -69,7 +69,7 @@ commands:
       - run:
           name: Install Node.js
           command: |
-            curl -sL https://deb.nodesource.com/setup_13.x | bash -
+            curl -sL https://deb.nodesource.com/setup_14.x | bash -
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI
@@ -85,11 +85,12 @@ commands:
           command: |
             cd ./HousingRegisterSearchListener/
             sls deploy --stage <<parameters.stage>> --conceal
-      - run:
-          name: Invoke elasticsearch deploy hook function
-          command: |
-            cd ./HousingRegisterSearchListener/
-            sls invoke --stage <<parameters.stage>> --function SearchDeploymentHookFunction --data \"${CIRCLE_BUILD_NUM}\"
+      # only required for initial search configuration or for re-indexing records
+      # - run:
+      #     name: Invoke elasticsearch deploy hook function
+      #     command: |
+      #       cd ./HousingRegisterSearchListener/
+      #       sls invoke --stage <<parameters.stage>> --function SearchDeploymentHookFunction --data \"${CIRCLE_BUILD_NUM}\"
 
 jobs:
   check-code-formatting:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 
-* @dendle
+* @LBHTKarki @Miles-Alford @martapederiva @sam-drumm @1JW1

--- a/HousingRegisterSearchListener.Tests/Dockerfile
+++ b/HousingRegisterSearchListener.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'

--- a/HousingRegisterSearchListener.Tests/HousingRegisterSearchListener.Tests.csproj
+++ b/HousingRegisterSearchListener.Tests/HousingRegisterSearchListener.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
@@ -21,7 +21,7 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.54.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HousingRegisterSearchListener/Dockerfile
+++ b/HousingRegisterSearchListener/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 ARG LBHPACKAGESTOKEN
 ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN

--- a/HousingRegisterSearchListener/HousingRegisterSearchListener.csproj
+++ b/HousingRegisterSearchListener/HousingRegisterSearchListener.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
 
@@ -22,7 +22,7 @@
     <PackageReference Include="Elastic.Apm.Elasticsearch" Version="1.16.1" />
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.49.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HousingRegisterSearchListener/Properties/launchSettings.json
+++ b/HousingRegisterSearchListener/Properties/launchSettings.json
@@ -2,9 +2,9 @@
   "profiles": {
     "Mock Lambda Test Tool": {
       "commandName": "Executable",
-      "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-3.1.exe",
+      "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-6.0.exe",
       "commandLineArgs": "--port 5050",
-      "workingDirectory": ".\\bin\\$(Configuration)\\netcoreapp3.1",
+      "workingDirectory": ".\\bin\\$(Configuration)\\net6.0",
       "environmentVariables": {
         "ENVIRONMENT": "LocalDevelopment",
         "DynamoDb_LocalServiceUrl": "http://localhost:8000",

--- a/HousingRegisterSearchListener/aws-lambda-tools-defaults.json
+++ b/HousingRegisterSearchListener/aws-lambda-tools-defaults.json
@@ -8,8 +8,8 @@
   "profile": "default",
   "region": "eu-west-2",
   "configuration": "Release",
-  "framework": "netcoreapp3.1",
-  "function-runtime": "dotnetcore3.1",
+  "framework": "net6.0",
+  "function-runtime": "net6.0",
   "function-memory-size": 256,
   "function-timeout": 30,
   "function-handler": "HousingRegisterSearchListener::HousingRegisterSearchListener.Functions.SearchDeploymentHookFunction::Handle"

--- a/HousingRegisterSearchListener/build.cmd
+++ b/HousingRegisterSearchListener/build.cmd
@@ -1,2 +1,2 @@
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package bin/release/netcoreapp3.1/lbh-housing-register-search-listener.zip
+dotnet lambda package --configuration release --framework net6.0 --output-package bin/release/net6.0/lbh-housing-register-search-listener.zip

--- a/HousingRegisterSearchListener/build.sh
+++ b/HousingRegisterSearchListener/build.sh
@@ -18,4 +18,4 @@ then
 fi
 
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package ./bin/release/netcoreapp3.1/lbh-housing-register-search-listener.zip
+dotnet lambda package --configuration release --framework net6.0 --output-package ./bin/release/net6.0/lbh-housing-register-search-listener.zip

--- a/HousingRegisterSearchListener/serverless.yml
+++ b/HousingRegisterSearchListener/serverless.yml
@@ -1,7 +1,7 @@
 service: lbh-housing-register-search-listener
 provider:
   name: aws
-  runtime: dotnetcore3.1
+  runtime: dotnet6
   memorySize: 2048
   tracing:
     lambda: true
@@ -10,7 +10,7 @@ provider:
   region: eu-west-2  
 
 package:
-  artifact: ./bin/release/netcoreapp3.1/lbh-housing-register-search-listener.zip
+  artifact: ./bin/release/net6.0/lbh-housing-register-search-listener.zip
 
 functions:
   HousingRegisterSearchListener:


### PR DESCRIPTION
## Link to JIRA ticket

[TS-1278](https://hackney.atlassian.net/browse/TS-1278)

## Describe this PR

### *What is the problem we're trying to solve*

Currently the listener is using .NET Core 3.1 which is now out of support. This prevents us from deploying any changes.

### *What changes have we introduced*

1. Update both projects to .NET 6
2. Update Docker setup to .NET 6
3. Update Lambda runtime to .NET 6
4. Update Node version in the pipeline to 14
5. Update Mock Lambda test tool config to .NET 6
6. Update build scripts to use .NET 6
7. Update `Microsoft.CodeAnalysis.NetAnalyzers` package to latest version 8.0.0
8. Disable elastic search deploy hook which is not necessary for every deployment. It is only required for initial search configuration or re-indexing of all records
9. Update code owners

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly



[TS-1278]: https://hackney.atlassian.net/browse/TS-1278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ