### PR TITLE
ts-1888: Upgrading .NET to 8.0 - pinning serverless to 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ commands:
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI
-          command: npm i -g serverless
+          command: npm i -g serverless@^3
       - run:
           name: Build lambda
           command: |


### PR DESCRIPTION
This is to circumvent the need to login to serverless or find alternative pipeline solutions