### PR TITLE
separate terraform and code deployment workflows for development

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,46 @@ commands:
           root: *workspace_root
           paths:
             - .aws
+
+  terraform-init-then-plan:
+    description: "Initializes and runs a plan from terraform configuration"
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform get -update=true
+            terraform init
+          name: get and init
+      - run:
+          name: plan
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform plan -out=plan.out
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - .aws
+            - project/*
+  
+  terraform-apply:
+    description: "Applies terraform configuration"
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          name: apply
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform apply -auto-approve plan.out      
+  
   terraform-init-then-apply:
     description: "Initializes and applies terraform configuration"
     parameters:
@@ -129,10 +169,15 @@ jobs:
     steps:
       - assume-role-and-persist-workspace:
           aws-account: $AWS_ACCOUNT_PRODUCTION
-  terraform-init-and-apply-to-development:
+  terraform-init-and-plan-development:
     executor: docker-terraform
     steps:
-      - terraform-init-then-apply:
+      - terraform-init-then-plan:
+          environment: "development"
+  terraform-apply-development:
+    executor: docker-terraform
+    steps:
+      - terraform-apply:
           environment: "development"
   terraform-init-and-apply-to-staging:
     executor: docker-terraform
@@ -169,26 +214,54 @@ workflows:
           context: api-nuget-token-context
       - assume-role-development:
           context: api-assume-role-housing-development-context
+          name: assume-role-development-for-code-deployment
           requires:
             - build-and-test
           filters:
             branches:
-              only: development
-      - terraform-init-and-apply-to-development:
-          requires:
-            - assume-role-development
-          filters:
-            branches:
-              only: development
+              only: development     
       - deploy-to-development:
           context:
             - api-nuget-token-context
             - "Serverless Framework"
           requires:
-            - terraform-init-and-apply-to-development
+            - assume-role-development-for-code-deployment
           filters:
             branches:
               only: development
+      - permit-development-terraform-workflow:
+          type: approval
+          filters:
+            branches:
+              only: development       
+      - assume-role-development:
+          context: api-assume-role-housing-development-context
+          name: assume-role-development-for-terraform-deployment
+          requires:
+            - permit-development-terraform-workflow
+          filters:
+            branches:
+              only: development     
+      - terraform-init-and-plan-development:
+          requires:
+            - assume-role-development-for-terraform-deployment
+          filters:
+            branches:
+              only: development
+      - permit-development-terraform-release:
+          type: approval
+          requires:
+            - terraform-init-and-plan-development
+          filters:
+            branches:
+              only: development
+      - terraform-apply-development:
+          requires:
+            - permit-development-terraform-release
+          filters:
+            branches:
+              only: development
+    
   check-and-deploy-staging-and-production:
       jobs:
       - check-code-formatting:


### PR DESCRIPTION
## Link to JIRA ticket

N/A

## Describe this PR

### *What is the problem we're trying to solve*

We want to separate Terraform and code deployment workflows, so they can be run independently.

### *What changes have we introduced*

Move terraform workflow outside the code workflows. Also add Terraform plan job, so the changes can be reviewed before applying. This is for development workflow only. Staging and production workflows to follow in separate PR.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

N/A
